### PR TITLE
Refactor flat_schema function to handle AllOf schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 
 ### TODO
 
-- [ ] Resolve `oneOf`, `anyOf`
+- [ ] Resolve schema type
+  - [ ] anyOf
+  - [ ] not
 - [ ] Resolve external reference
 
 ## How to use

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -226,7 +226,7 @@ pub fn flat_schema(
             let all_of = items(all_of, api)
                 .map(|x| {
                     let x = x?;
-                    let (x, _) = flat_schema(&x, api, is_required)?;
+                    let (x, _) = flat_schema(x, api, is_required)?;
                     Ok(x)
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -307,12 +307,12 @@ mod tests {
         let schema = serde_yaml::from_str::<MediaType>(schema).unwrap();
         let schema = schema.schema.unwrap();
         let schema = schema.as_item().unwrap();
-        let (schema, _) = super::flat_schema(&schema, &OpenAPI::default(), true).unwrap();
+        let (schema, _) = super::flat_schema(schema, &OpenAPI::default(), true).unwrap();
 
         if let SchemaType::Object(obj) = schema {
             assert_eq!(obj.len(), 4);
         } else {
-            assert!(false);
+            unreachable!()
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Read;
 use std::{env::current_dir, path::PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context, Ok, Result};
 use indexmap::IndexMap;
 use inquire::Select;
 use openapiv3::{
@@ -222,7 +222,25 @@ pub fn flat_schema(
 
             Ok((select, is_required))
         }
-        openapiv3::SchemaKind::AllOf { .. } => todo!("AllOf"),
+        openapiv3::SchemaKind::AllOf { all_of } => {
+            let all_of = items(all_of, api)
+                .map(|x| {
+                    let x = x?;
+                    let (x, _) = flat_schema(&x, api, is_required)?;
+                    Ok(x)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let mut obj = IndexMap::new();
+            for x in all_of {
+                if let SchemaType::Object(x) = x {
+                    for (k, v) in x {
+                        obj.insert(k.to_owned(), v);
+                    }
+                }
+            }
+
+            Ok((SchemaType::Object(obj), is_required))
+        }
         openapiv3::SchemaKind::AnyOf { .. } => todo!("AnyOf"),
         openapiv3::SchemaKind::Not { .. } => todo!("Not"),
         openapiv3::SchemaKind::Any(_) => todo!("Any"),
@@ -231,8 +249,10 @@ pub fn flat_schema(
 
 #[cfg(test)]
 mod tests {
+    use crate::schema::SchemaType;
+
     use super::ReadSchema;
-    use openapiv3::{OpenAPI, PathItem, Type};
+    use openapiv3::{MediaType, OpenAPI, PathItem, Type};
     use std::path::PathBuf;
 
     #[test]
@@ -259,5 +279,40 @@ mod tests {
         let schema = ReadSchema::<PathItem>::get_schema(path).unwrap();
 
         assert!(schema.schema.get.is_some());
+    }
+
+    #[test]
+    fn test_flatten_all_of() {
+        let schema = r#"
+            schema:
+                allOf:
+                    - type: object
+                      required:
+                        - created_at
+                      properties:
+                        created_at:
+                            type: string
+                            format: date-time
+                        updated_at:
+                            type: string
+                            format: date-time
+                        deleted_at:
+                            type: string
+                            format: date-time
+                    - type: object
+                      properties:
+                        test:
+                            type: string
+        "#;
+        let schema = serde_yaml::from_str::<MediaType>(schema).unwrap();
+        let schema = schema.schema.unwrap();
+        let schema = schema.as_item().unwrap();
+        let (schema, _) = super::flat_schema(&schema, &OpenAPI::default(), true).unwrap();
+
+        if let SchemaType::Object(obj) = schema {
+            assert_eq!(obj.len(), 4);
+        } else {
+            assert!(false);
+        }
     }
 }

--- a/tests/fixtures/example.yaml
+++ b/tests/fixtures/example.yaml
@@ -1,27 +1,27 @@
 openapi: 3.0.0
-info: 
+info:
   title: Link Example
   version: 1.0.0
-paths: 
-  /2.0/users/{username}: 
-    get: 
+paths:
+  /2.0/users/{username}:
+    get:
       operationId: getUserByName
-      parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
-      responses: 
-        '200':
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
           description: The User
           content:
             application/json:
-              schema: 
-                $ref: '#/components/schemas/user'
+              schema:
+                $ref: "#/components/schemas/user"
           links:
             userRepositories:
-              $ref: '#/components/links/UserRepositories'
+              $ref: "#/components/links/UserRepositories"
   /2.0/repositories/{username}:
     get:
       operationId: getRepositoriesByOwner
@@ -32,21 +32,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: repositories owned by the supplied user
-          content: 
+          content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/repository'
+                  $ref: "#/components/schemas/repository"
           links:
             userRepository:
-              $ref: '#/components/links/UserRepository'
-  /2.0/repositories/{username}/{slug}: 
-    get: 
+              $ref: "#/components/links/UserRepository"
+  /2.0/repositories/{username}/{slug}:
+    get:
       operationId: getRepository
-      parameters: 
+      parameters:
         - name: username
           in: path
           required: true
@@ -57,97 +57,113 @@ paths:
           required: true
           schema:
             type: string
-      responses: 
-        '200':
+      responses:
+        "200":
           description: The repository
           content:
-              application/json: 
-                schema: 
-                  $ref: '#/components/schemas/repository'
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repository"
           links:
             repositoryPullRequests:
-              $ref: '#/components/links/RepositoryPullRequests'
-  /2.0/repositories/{username}/{slug}/pullrequests: 
-    get: 
+              $ref: "#/components/links/RepositoryPullRequests"
+  /2.0/repositories/{username}/{slug}/pullrequests:
+    get:
       operationId: getPullRequestsByRepository
-      parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: slug
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: state
-        in: query
-        schema:
-          type: string
-          enum: 
-            - open
-            - merged
-            - declined
-      responses: 
-        '200':
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          schema:
+            type: string
+            enum:
+              - open
+              - merged
+              - declined
+      responses:
+        "200":
           description: an array of pull request objects
           content:
-            application/json: 
-              schema: 
+            application/json:
+              schema:
                 type: array
-                items: 
-                  $ref: '#/components/schemas/pullrequest'
-  /2.0/repositories/{username}/{slug}/pullrequests/{pid}: 
-    get: 
+                items:
+                  $ref: "#/components/schemas/pullrequest"
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}:
+    get:
       operationId: getPullRequestsById
-      parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: slug
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: pid
-        in: path
-        required: true
-        schema:
-          type: string
-      responses: 
-        '200':
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: pid
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
           description: a pull request object
           content:
-            application/json: 
-              schema: 
-                $ref: '#/components/schemas/pullrequest'
+            application/json:
+              schema:
+                $ref: "#/components/schemas/pullrequest"
           links:
             pullRequestMerge:
-              $ref: '#/components/links/PullRequestMerge'
-  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge: 
-    post: 
+              $ref: "#/components/links/PullRequestMerge"
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge:
+    post:
       operationId: mergePullRequest
-      parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: slug
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: pid
-        in: path
-        required: true
-        schema:
-          type: string
-      responses: 
-        '204':
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: pid
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: the PR was successfully merged
+  /2.0/schema/test/all_of:
+    post:
+      operationId: testAllOf
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/dateInfo"
+                - type: object
+                  properties:
+                    test:
+                      type: string
+      responses:
+        "200":
           description: the PR was successfully merged
 components:
   links:
@@ -165,9 +181,9 @@ components:
     RepositoryPullRequests:
       # returns '#/components/schemas/pullrequest'
       operationId: getPullRequestsByRepository
-      parameters: 
-          username: $response.body#/owner/username
-          slug: $response.body#/slug
+      parameters:
+        username: $response.body#/owner/username
+        slug: $response.body#/slug
     PullRequestMerge:
       # executes /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge
       operationId: mergePullRequest
@@ -177,29 +193,43 @@ components:
         pid: $response.body#/id
     NoParams:
       operationRef: xyz
-  schemas: 
-    user: 
+  schemas:
+    user:
       type: object
-      properties: 
-        username: 
+      properties:
+        username:
           type: string
-        uuid: 
+        uuid:
           type: string
-    repository: 
+    repository:
       type: object
-      properties: 
-        slug: 
+      properties:
+        slug:
           type: string
-        owner: 
-          $ref: '#/components/schemas/user'
-    pullrequest: 
+        owner:
+          $ref: "#/components/schemas/user"
+    pullrequest:
       type: object
-      properties: 
-        id: 
+      properties:
+        id:
           type: integer
-        title: 
+        title:
           type: string
-        repository: 
-          $ref: '#/components/schemas/repository'
-        author: 
-          $ref: '#/components/schemas/user'
+        repository:
+          $ref: "#/components/schemas/repository"
+        author:
+          $ref: "#/components/schemas/user"
+    dateInfo:
+      type: object
+      required:
+        - created_at
+      properties:
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        deleted_at:
+          type: string
+          format: date-time


### PR DESCRIPTION
This pull request refactors the flat_schema function to handle AllOf schemas in the OpenAPI specification. It introduces support for flattening multiple schemas into a single object schema, allowing for more flexible and modular schema definitions. This change improves the overall functionality and usability of the flat_schema function.