### PR TITLE
Add CLI options for path and request method

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use reqwest::Method;
 use std::{error::Error, path::PathBuf};
 
 use clap::Parser;
@@ -11,6 +12,10 @@ pub struct Cli {
     pub base_url: Option<String>,
     #[arg(long, short = 'H', value_parser = parse_key_val::<String, String>)]
     pub headers: Option<Vec<(String, String)>>,
+    #[arg(long, short)]
+    pub path: Option<String>,
+    #[arg(long = "request", short = 'X')]
+    pub method: Option<Method>,
 }
 
 fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
         .or(api.schema.servers.first().map(|x| x.url.clone()))
         .with_context(|| "No servers in schema")?;
 
-    let mut init = APIPrompt::new(&api, &server).prompt()?;
+    let mut init = APIPrompt::new(&api, &server, cli.path, cli.method).prompt()?;
     if let Some(from_cli) = cli.headers {
         init.header = [init.header, from_cli].concat();
     }


### PR DESCRIPTION
This pull request adds CLI options for specifying the path and request method in the command-line interface. This allows users to customize the path and method when making API requests.